### PR TITLE
Add category to library.properties

### DIFF
--- a/Apio/library.properties
+++ b/Apio/library.properties
@@ -4,5 +4,6 @@ author=Apio
 maintainer=Alessandro Chelli <alessandrochelli@gmail.com>
 sentence=This library is the core of Apio Systems, it is refers to hardware layer
 paragraph=
+category=Other
 url=https://github.com/ApioLab/library
 architectures=avr


### PR DESCRIPTION
Lack of a category field in library.properties causes the warning:
```
WARNING: Category '' in library Apio is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format